### PR TITLE
The version 1.0.6 of cloudfoundry-client-lib-shaded was not binary co…

### DIFF
--- a/lib/org/cloudfoundry/cloudfoundry-client-lib-shaded/1.1.3/cloudfoundry-client-lib-shaded-1.1.3.pom
+++ b/lib/org/cloudfoundry/cloudfoundry-client-lib-shaded/1.1.3/cloudfoundry-client-lib-shaded-1.1.3.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.cloudfoundry</groupId>
+  <artifactId>cloudfoundry-client-lib-shaded</artifactId>
+  <version>1.1.3</version>
+  <description>POM was created from install:install-file</description>
+</project>

--- a/lib/org/cloudfoundry/cloudfoundry-client-lib-shaded/maven-metadata-local.xml
+++ b/lib/org/cloudfoundry/cloudfoundry-client-lib-shaded/maven-metadata-local.xml
@@ -3,10 +3,11 @@
   <groupId>org.cloudfoundry</groupId>
   <artifactId>cloudfoundry-client-lib-shaded</artifactId>
   <versioning>
-    <release>1.0.6</release>
+    <release>1.1.3</release>
     <versions>
       <version>1.0.6</version>
+      <version>1.1.3</version>
     </versions>
-    <lastUpdated>20141209200132</lastUpdated>
+    <lastUpdated>20150615112029</lastUpdated>
   </versioning>
 </metadata>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.cloudfoundry</groupId>
       <artifactId>cloudfoundry-client-lib-shaded</artifactId>
-      <version>1.0.6</version>
+      <version>1.1.3</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisherTest.java
+++ b/src/test/java/com/activestate/cloudfoundryjenkins/CloudFoundryPushPublisherTest.java
@@ -29,7 +29,6 @@ import org.cloudfoundry.client.lib.CloudFoundryClient;
 import org.cloudfoundry.client.lib.domain.CloudService;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.ExtractResourceSCM;
@@ -350,7 +349,7 @@ public class CloudFoundryPushPublisherTest {
 
     // All the tests below are failure cases
 
-    @Ignore
+    @Test
     @WithTimeout(300)
     public void testPerformCustomTimeout() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
@@ -377,7 +376,7 @@ public class CloudFoundryPushPublisherTest {
                 log.contains("ERROR: The application failed to start after"));
     }
 
-    @Ignore 
+    @Test 
     public void testPerformEnvVarsManifestFile() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("python-env.zip")));
@@ -406,7 +405,7 @@ public class CloudFoundryPushPublisherTest {
         assertTrue("App did not have correct ENV_VAR_THREE", content.contains("ENV_VAR_THREE: value3"));
     }
 
-    @Ignore 
+    @Test 
     public void testPerformServicesNamesManifestFile() throws Exception {
         CloudService service1 = new CloudService();
         service1.setName("mysql_service1");
@@ -446,7 +445,7 @@ public class CloudFoundryPushPublisherTest {
         assertTrue("App did not have mysql_service2 bound", content.contains("mysql_service2"));
     }
 
-    @Ignore
+    @Test
     public void testPerformNoRoute() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("hello-java.zip")));
@@ -476,7 +475,7 @@ public class CloudFoundryPushPublisherTest {
         assertEquals("Get request did not respond 404 Not Found", 404, statusCode);
     }
 
-    @Ignore
+    @Test
     public void testPerformUnknownHost() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("hello-java.zip")));
@@ -493,7 +492,7 @@ public class CloudFoundryPushPublisherTest {
         assertTrue("Build did not write error message", s.contains("ERROR: Unknown host"));
     }
 
-    @Ignore
+    @Test
     public void testPerformWrongCredentials() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
         project.setScm(new ExtractResourceSCM(getClass().getResource("hello-java.zip")));


### PR DESCRIPTION
…mpatible with 1.532 of jenkins. This resulted JVM hang when CF push operation failed and Jenkins job never compelted. The problem was traced to the compile time dependency of commons-codec v1.3 with the cloudfoundry-client-lib whereas the runtime version was 1.8.  Created new shaded lib of cloudfounbdry-client-lib from https://github.com/jayaramsankara/cf-java-client. The version was built from v1.1.3 of the client lib.
